### PR TITLE
Config für Replenishment angepasst

### DIFF
--- a/map.tmj
+++ b/map.tmj
@@ -451,7 +451,7 @@
                         {
                          "name":"jitsiConfig",
                          "type":"string",
-                         "value":"{ \"p2p\": { \"enabled\": false, \"preferredCodec\": \"VP9\"}, \"videoQuality\": {\n\"preferredCodec\": \"VP9\", \"maxBitratesVideo\": { \"low\": 100000, \"standard\": 500000, \"high\": 3000000, \"H264\": { \"low\": 100000, \"standard\": 500000, \"high\": 3000000 }, \"VP8\" : { \"low\": 100000, \"standard\": 500000, \"high\": 3000000 }, \"VP9\": { \"low\": 100000, \"standard\": 500000, \"high\": 3000000 } }, \"minHeightForQualityLvl\": { \"360\": \"standard\", \"720\": \"high\" } }, \"disableSimulcast\": true, \"enableLayerSuspension\": true, \"disableRtx\": true, \"enableTcc\": true}"
+                         "value":"{ \"p2p\": { \"enabled\": false, \"preferredCodec\": \"VP9\"}, \"videoQuality\": {\n\"preferredCodec\": \"VP9\", \"maxBitratesVideo\": { \"low\": 32000, \"standard\": 128000, \"high\": 512000, \"H264\": { \"low\": 32000, \"standard\": 128000, \"high\": 512000 }, \"VP8\" : { \"low\": 32000, \"standard\": 128000, \"high\": 512000 }, \"VP9\": { \"low\": 32000, \"standard\": 128000, \"high\": 512000 } }, \"minHeightForQualityLvl\": { \"360\": \"standard\", \"720\": \"high\" } }, \"disableSimulcast\": true, \"enableLayerSuspension\": true, \"disableRtx\": true, \"enableTcc\": true }"
                         }, 
                         {
                          "name":"jitsiRoom",
@@ -541,7 +541,7 @@
                         {
                          "name":"jitsiConfig",
                          "type":"string",
-                         "value":"{ \"p2p\": { \"enabled\": false, \"preferredCodec\": \"VP9\"}, \"videoQuality\": {\n\"preferredCodec\": \"VP9\", \"maxBitratesVideo\": { \"low\": 100000, \"standard\": 500000, \"high\": 3000000, \"H264\": { \"low\": 100000, \"standard\": 500000, \"high\": 3000000 }, \"VP8\" : { \"low\": 100000, \"standard\": 500000, \"high\": 3000000 }, \"VP9\": { \"low\": 100000, \"standard\": 500000, \"high\": 3000000 } }, \"minHeightForQualityLvl\": { \"360\": \"standard\", \"720\": \"high\" } }, \"disableSimulcast\": true, \"enableLayerSuspension\": true, \"disableRtx\": true, \"enableTcc\": true}"
+                         "value":"{ \"p2p\": { \"enabled\": false, \"preferredCodec\": \"VP9\"}, \"videoQuality\": {\n\"preferredCodec\": \"VP9\", \"maxBitratesVideo\": { \"low\": 32000, \"standard\": 128000, \"high\": 512000, \"H264\": { \"low\": 32000, \"standard\": 128000, \"high\": 512000 }, \"VP8\" : { \"low\": 32000, \"standard\": 128000, \"high\": 512000 }, \"VP9\": { \"low\": 32000, \"standard\": 128000, \"high\": 512000 } }, \"minHeightForQualityLvl\": { \"360\": \"standard\", \"720\": \"high\" } }, \"disableSimulcast\": true, \"enableLayerSuspension\": true, \"disableRtx\": true, \"enableTcc\": true }"
                         }, 
                         {
                          "name":"jitsiRoom",
@@ -631,7 +631,7 @@
                         {
                          "name":"jitsiConfig",
                          "type":"string",
-                         "value":"{ \"p2p\": { \"enabled\": false, \"preferredCodec\": \"VP9\"}, \"videoQuality\": {\n\"preferredCodec\": \"VP9\", \"maxBitratesVideo\": { \"low\": 100000, \"standard\": 500000, \"high\": 3000000, \"H264\": { \"low\": 100000, \"standard\": 500000, \"high\": 3000000 }, \"VP8\" : { \"low\": 100000, \"standard\": 500000, \"high\": 3000000 }, \"VP9\": { \"low\": 100000, \"standard\": 500000, \"high\": 3000000 } }, \"minHeightForQualityLvl\": { \"360\": \"standard\", \"720\": \"high\" } }, \"disableSimulcast\": true, \"enableLayerSuspension\": true, \"disableRtx\": true, \"enableTcc\": true}"
+                         "value":"{ \"p2p\": { \"enabled\": false, \"preferredCodec\": \"VP9\"}, \"videoQuality\": {\n\"preferredCodec\": \"VP9\", \"maxBitratesVideo\": { \"low\": 32000, \"standard\": 128000, \"high\": 512000, \"H264\": { \"low\": 32000, \"standard\": 128000, \"high\": 512000 }, \"VP8\" : { \"low\": 32000, \"standard\": 128000, \"high\": 512000 }, \"VP9\": { \"low\": 32000, \"standard\": 128000, \"high\": 512000 } }, \"minHeightForQualityLvl\": { \"360\": \"standard\", \"720\": \"high\" } }, \"disableSimulcast\": true, \"enableLayerSuspension\": true, \"disableRtx\": true, \"enableTcc\": true }"
                         }, 
                         {
                          "name":"jitsiRoom",
@@ -721,7 +721,7 @@
                         {
                          "name":"jitsiConfig",
                          "type":"string",
-                         "value":"{ \"p2p\": { \"enabled\": false, \"preferredCodec\": \"VP9\"}, \"videoQuality\": {\n\"preferredCodec\": \"VP9\", \"maxBitratesVideo\": { \"low\": 100000, \"standard\": 500000, \"high\": 3000000, \"H264\": { \"low\": 100000, \"standard\": 500000, \"high\": 3000000 }, \"VP8\" : { \"low\": 100000, \"standard\": 500000, \"high\": 3000000 }, \"VP9\": { \"low\": 100000, \"standard\": 500000, \"high\": 3000000 } }, \"minHeightForQualityLvl\": { \"360\": \"standard\", \"720\": \"high\" } }, \"disableSimulcast\": true, \"enableLayerSuspension\": true, \"disableRtx\": true, \"enableTcc\": true}"
+                         "value":"{ \"p2p\": { \"enabled\": false, \"preferredCodec\": \"VP9\"}, \"videoQuality\": {\n\"preferredCodec\": \"VP9\", \"maxBitratesVideo\": { \"low\": 32000, \"standard\": 128000, \"high\": 512000, \"H264\": { \"low\": 32000, \"standard\": 128000, \"high\": 512000 }, \"VP8\" : { \"low\": 32000, \"standard\": 128000, \"high\": 512000 }, \"VP9\": { \"low\": 32000, \"standard\": 128000, \"high\": 512000 } }, \"minHeightForQualityLvl\": { \"360\": \"standard\", \"720\": \"high\" } }, \"disableSimulcast\": true, \"enableLayerSuspension\": true, \"disableRtx\": true, \"enableTcc\": true }"
                         }, 
                         {
                          "name":"jitsiRoom",


### PR DESCRIPTION
- Bitrate an den Hauptcall im Computerraum angeglichen, damit die Leitung weniger belastet wird, wenn viele an einem Replenishment teilnehmen